### PR TITLE
update runtime to execute statechange right away

### DIFF
--- a/packages/framework/src/runtime/runtime.ts
+++ b/packages/framework/src/runtime/runtime.ts
@@ -185,7 +185,7 @@ export class Runtime {
         const changed = new Set<Component>();
         let oneUpdate = [...this.updateViewOnce()];
         while(oneUpdate.length > 0) {
-            oneUpdate.forEach((item) => changed.add(item))
+            oneUpdate.forEach(item => changed.add(item));
             oneUpdate = [...this.updateViewOnce()];
         }
         this.viewUpdatePending = false;

--- a/packages/framework/src/runtime/runtime.ts
+++ b/packages/framework/src/runtime/runtime.ts
@@ -210,6 +210,8 @@ export class Runtime {
         if (!this.viewUpdatePending) {
             this.viewUpdatePending = true;
             this.updateView();
+        } else {
+            this.$tick(this.updateView);
         }
     }
 }

--- a/packages/framework/src/runtime/runtime.ts
+++ b/packages/framework/src/runtime/runtime.ts
@@ -181,12 +181,12 @@ export class Runtime {
     private updateView = () => {
         const stateTime = performance.now();
 
-        this.viewUpdatePending = false;
+        
         const changed = new Set<Component>();
         for (const i of this.updateViewOnce()) {
             changed.add(i);
         }
-
+        this.viewUpdatePending = false;
         if (changed.size > 0) {
             this.$tick(() => {
                 changed.forEach(i => {
@@ -209,7 +209,7 @@ export class Runtime {
     private triggerViewUpdate() {
         if (!this.viewUpdatePending) {
             this.viewUpdatePending = true;
-            this.$tick(this.updateView);
+            this.updateView();
         }
     }
 }

--- a/packages/framework/src/runtime/runtime.ts
+++ b/packages/framework/src/runtime/runtime.ts
@@ -37,7 +37,7 @@ export class Runtime {
     };
 
     private ignoreStateChanges = new Set<Component>();
-    private viewUpdatePending: boolean = false;
+    private updateTriggered: boolean = false;
 
     public $tick = (fn: FrameRequestCallback) => window.requestAnimationFrame(fn);
     public execute<Comp extends Component>(instance: Comp, method: (...args: any[]) => any, ...args: any[]) {
@@ -180,15 +180,15 @@ export class Runtime {
 
     private updateView = () => {
         const stateTime = performance.now();
-
-        
         const changed = new Set<Component>();
+
         let oneUpdate = [...this.updateViewOnce()];
         while(oneUpdate.length > 0) {
             oneUpdate.forEach(item => changed.add(item));
             oneUpdate = [...this.updateViewOnce()];
         }
-        this.viewUpdatePending = false;
+        this.updateTriggered = false;
+        
         if (changed.size > 0) {
             changed.forEach(i => {
                 const req = this.pending.requested.get(i) || (i.$afterUpdate && i.$afterUpdate());
@@ -207,8 +207,8 @@ export class Runtime {
     };
 
     private triggerViewUpdate() {
-        if (!this.viewUpdatePending) {
-            this.viewUpdatePending = true;
+        if (!this.updateTriggered) {
+            this.updateTriggered = true;
             this.updateView();
         }
     }

--- a/packages/framework/src/runtime/runtime.ts
+++ b/packages/framework/src/runtime/runtime.ts
@@ -183,20 +183,20 @@ export class Runtime {
 
         
         const changed = new Set<Component>();
-        for (const i of this.updateViewOnce()) {
-            changed.add(i);
+        let oneUpdate = [...this.updateViewOnce()];
+        while(oneUpdate.length > 0) {
+            oneUpdate.forEach((item) => changed.add(item))
+            oneUpdate = [...this.updateViewOnce()];
         }
         this.viewUpdatePending = false;
         if (changed.size > 0) {
-            this.$tick(() => {
-                changed.forEach(i => {
-                    const req = this.pending.requested.get(i) || (i.$afterUpdate && i.$afterUpdate());
-                    if (req && !req.next().done) {
-                        this.pending.requested.set(i, req);
-                    } else {
-                        this.pending.requested.delete(i);
-                    }
-                });
+            changed.forEach(i => {
+                const req = this.pending.requested.get(i) || (i.$afterUpdate && i.$afterUpdate());
+                if (req && !req.next().done) {
+                    this.pending.requested.set(i, req);
+                } else {
+                    this.pending.requested.delete(i);
+                }
             });
         }
         this.$stats.push({
@@ -210,8 +210,6 @@ export class Runtime {
         if (!this.viewUpdatePending) {
             this.viewUpdatePending = true;
             this.updateView();
-        } else {
-            this.$tick(this.updateView);
         }
     }
 }

--- a/tsx-air.code-workspace
+++ b/tsx-air.code-workspace
@@ -45,6 +45,7 @@
 		"typescript.tsdk": "tsx-air/node_modules/typescript/lib",
 		"cSpell.words": [
 			"Bitmask",
+			"Bitmasks",
 			"ESNEXT",
 			"Namepath",
 			"Unparsed",
@@ -54,6 +55,7 @@
 			"downlevel",
 			"extendz",
 			"jsxroot",
+			"prebuild",
 			"prerender",
 			"quotemark",
 			"sourcemap",


### PR DESCRIPTION
## stateless run comparison
| change | 60 FPS | 144 FPS | Total frames | frames/update |
| :--- | :--- | :--- | :---: | :---: |
| original | 3245ms | 1386ms | 201 | 2 |
| [debounce pre-render](https://github.com/wixplosives/tsx-air/pull/39/files#diff-3182845b230cb642ffc258303fed28f5L184) | 3575ms | 2086ms | 301 | 3 |
| [sync state update](https://github.com/wixplosives/tsx-air/pull/39/files#diff-3182845b230cb642ffc258303fed28f5L212) | 1560ms | 691ms | 101 | 1 |